### PR TITLE
Raise unless iterations is given as an integer >= 1

### DIFF
--- a/lib/plug/crypto/key_generator.ex
+++ b/lib/plug/crypto/key_generator.ex
@@ -37,11 +37,11 @@ defmodule Plug.Crypto.KeyGenerator do
     cache = Keyword.get(opts, :cache)
 
     cond do
-      length > @max_length ->
-        raise ArgumentError, "length must be less than or equal to #{@max_length}"
-
       not is_integer(iterations) or iterations < 1 ->
         raise ArgumentError, "iterations must be an integer >= 1"
+
+      length > @max_length ->
+        raise ArgumentError, "length must be less than or equal to #{@max_length}"
 
       true ->
         with_cache(cache, {secret, salt, iterations, length, digest}, fn ->

--- a/lib/plug/crypto/key_generator.ex
+++ b/lib/plug/crypto/key_generator.ex
@@ -40,10 +40,10 @@ defmodule Plug.Crypto.KeyGenerator do
       length > @max_length ->
         raise ArgumentError, "length must be less than or equal to #{@max_length}"
 
-      !is_integer(iterations) or iterations < 1 ->
+      not is_integer(iterations) or iterations < 1 ->
         raise ArgumentError, "iterations must be an integer >= 1"
 
-      :else ->
+      true ->
         with_cache(cache, {secret, salt, iterations, length, digest}, fn ->
           generate(mac_fun(digest, secret), salt, iterations, length, 1, [], 0)
         end)

--- a/lib/plug/crypto/key_generator.ex
+++ b/lib/plug/crypto/key_generator.ex
@@ -36,12 +36,17 @@ defmodule Plug.Crypto.KeyGenerator do
     digest = Keyword.get(opts, :digest, :sha256)
     cache = Keyword.get(opts, :cache)
 
-    if length > @max_length do
-      raise ArgumentError, "length must be less than or equal to #{@max_length}"
-    else
-      with_cache(cache, {secret, salt, iterations, length, digest}, fn ->
-        generate(mac_fun(digest, secret), salt, iterations, length, 1, [], 0)
-      end)
+    cond do
+      length > @max_length ->
+        raise ArgumentError, "length must be less than or equal to #{@max_length}"
+
+      !is_integer(iterations) or iterations < 1 ->
+        raise ArgumentError, "iterations must be an integer >= 1"
+
+      :else ->
+        with_cache(cache, {secret, salt, iterations, length, digest}, fn ->
+          generate(mac_fun(digest, secret), salt, iterations, length, 1, [], 0)
+        end)
     end
   rescue
     e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(System.stacktrace())

--- a/test/plug/crypto/key_generator_test.exs
+++ b/test/plug/crypto/key_generator_test.exs
@@ -12,6 +12,14 @@ defmodule Plug.Crypto.KeyGeneratorTest do
     end
   end
 
+  test "returns an error if iterations is not an integer >= 1" do
+    for i <- [32.0, -1, nil, "many", :lots] do
+      assert_raise ArgumentError, "iterations must be an integer >= 1", fn ->
+        generate("secret", "salt", iterations: i)
+      end
+    end
+  end
+
   test "it works" do
     key = generate("password", "salt", iterations: 1, length: 20, digest: :sha)
     assert byte_size(key) == 20


### PR DESCRIPTION
The documentation for `generate/3` says to increase key iterations to at
least "2^16" for passwords. When I tried passing `:math.pow(2, 16)` to
see how long it took, I was surprised to see the function hang
indefinitely.

The issue was that the generator expects to be able to subtract 1 from
the iterations count until the result equals `0`, but with a float it
would hit `0.0` and keep subtracting forever. The same problem would
happen if the iterations count were given as a negative number.