### PR TITLE
Include LICENSE file when publishing to hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Plug.Crypto.MixProject do
         "José Valim"
       ],
       links: %{"GitHub" => "https://github.com/elixir-plug/plug_crypto"},
-      files: ["lib", "mix.exs", "README.md", "CHANGELOG.md"]
+      files: ["lib", "mix.exs", "README.md", "CHANGELOG.md", "LICENSE"]
     }
   end
 end


### PR DESCRIPTION
Makes it easier for tools to parse license information and generate 3rd-party license notices files.