### PR TITLE
Replace obsolete stacktraces and bump requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - stage: test
 
-    - elixir: '1.5.0'
+    - elixir: '1.7.4'
       otp_release: '19.3'
 
     - stage: check formatted

--- a/lib/plug/crypto/key_generator.ex
+++ b/lib/plug/crypto/key_generator.ex
@@ -53,7 +53,7 @@ defmodule Plug.Crypto.KeyGenerator do
         end)
     end
   rescue
-    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(System.stacktrace())
+    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(__STACKTRACE__)
   end
 
   defp with_cache(nil, _key, fun), do: fun.()

--- a/lib/plug/crypto/message_encryptor.ex
+++ b/lib/plug/crypto/message_encryptor.ex
@@ -34,7 +34,7 @@ defmodule Plug.Crypto.MessageEncryptor do
       when is_binary(message) and byte_size(secret) > 0 and is_binary(sign_secret) do
     aes128_gcm_encrypt(message, secret, sign_secret)
   rescue
-    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(System.stacktrace())
+    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(__STACKTRACE__)
   end
 
   @doc """
@@ -44,7 +44,7 @@ defmodule Plug.Crypto.MessageEncryptor do
       when is_binary(encrypted) and byte_size(secret) > 0 and is_binary(sign_secret) do
     aes128_gcm_decrypt(encrypted, secret, sign_secret)
   rescue
-    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(System.stacktrace())
+    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(__STACKTRACE__)
   end
 
   # Encrypts and authenticates a message using AES128-GCM mode.

--- a/lib/plug/crypto/message_verifier.ex
+++ b/lib/plug/crypto/message_verifier.ex
@@ -22,7 +22,7 @@ defmodule Plug.Crypto.MessageVerifier do
              digest_type in [:sha256, :sha384, :sha512] do
     hmac_sha2_sign(message, secret, digest_type)
   rescue
-    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(System.stacktrace())
+    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(__STACKTRACE__)
   end
 
   @doc """
@@ -31,7 +31,7 @@ defmodule Plug.Crypto.MessageVerifier do
   def verify(signed, secret) when is_binary(signed) and byte_size(secret) > 0 do
     hmac_sha2_verify(signed, secret)
   rescue
-    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(System.stacktrace())
+    e -> reraise e, Plug.Crypto.prune_args_from_stacktrace(__STACKTRACE__)
   end
 
   ## Signature Algorithms

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Plug.Crypto.MixProject do
     [
       app: :plug_crypto,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
Plug itself seems to [have fixed it and only supports elixir 1.7](https://github.com/elixir-plug/plug/commit/65986ad32f9aaae3be50dc80cbdd19b326578da7).
This will avoid warnings on elixir 1.11.