### PR TITLE
Use `import Bitwise` instead of `use Bitwise`

### DIFF
--- a/lib/plug/crypto.ex
+++ b/lib/plug/crypto.ex
@@ -6,7 +6,7 @@ defmodule Plug.Crypto do
   `Plug.Crypto.MessageEncryptor`, and `Plug.Crypto.MessageVerifier`.
   """
 
-  use Bitwise
+  import Bitwise
   alias Plug.Crypto.{KeyGenerator, MessageVerifier, MessageEncryptor}
 
   @doc """

--- a/lib/plug/crypto/key_generator.ex
+++ b/lib/plug/crypto/key_generator.ex
@@ -14,7 +14,7 @@ defmodule Plug.Crypto.KeyGenerator do
   See http://tools.ietf.org/html/rfc2898#section-5.2
   """
 
-  use Bitwise
+  import Bitwise
   @max_length bsl(1, 32) - 1
 
   @doc """


### PR DESCRIPTION
Fixes warnings for Elixir >= `1.14`