### PR TITLE
Bump Elixir to test against to 14.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       MIX_ENV: test
     strategy:
@@ -19,13 +19,13 @@ jobs:
               elixir: 1.7.4
               otp: 20.3.8.26
           - pair:
-              elixir: 1.13.4
-              otp: 25.0.4
+              elixir: 1.14.2
+              otp: 25.2
             lint: lint
     steps:
       - uses: actions/checkout@v2
 
-      - uses: erlef/setup-elixir@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.pair.otp}}
           elixir-version: ${{matrix.pair.elixir}}


### PR DESCRIPTION
Hey can we perhaps now bump to ~~1.10 and~~ 1.14?
https://hexdocs.pm/elixir/main/compatibility-and-deprecations.html

~~Last change was #31 where minimum required version remained 1.7. On the other hand since [plug specifies 1.10](https://github.com/elixir-plug/plug/blob/v1.14.0/mix.exs#L12) it'll feel better if we can follow it, won't it?~~ This dropped in favor of https://github.com/elixir-plug/plug_crypto/pull/32#issuecomment-1381904243.

Other changes included is what I used to validate in fork. Basically it's how plug configures it.