### PR TITLE
Allow custom AAD to be provided to message encryptor

### DIFF
--- a/test/plug/crypto/message_encryptor_test.exs
+++ b/test/plug/crypto/message_encryptor_test.exs
@@ -11,7 +11,7 @@ defmodule Plug.Crypto.MessageEncryptorTest do
 
   test "it encrypts/decrypts a message" do
     data = <<0, "hełłoworld", 0>>
-    encrypted = ME.encrypt(<<0, "hełłoworld", 0>>, @right, @right)
+    encrypted = ME.encrypt(<<0, "hełłoworld", 0>>, "right aad", @right, @right)
 
     decrypted = ME.decrypt(encrypted, @wrong, @wrong)
     assert decrypted == :error
@@ -22,7 +22,10 @@ defmodule Plug.Crypto.MessageEncryptorTest do
     decrypted = ME.decrypt(encrypted, @wrong, @right)
     assert decrypted == :error
 
-    decrypted = ME.decrypt(encrypted, @right, @right)
+    decrypted = ME.decrypt(encrypted, "wrong aad", @right, @right)
+    assert decrypted == :error
+
+    decrypted = ME.decrypt(encrypted, "right aad", @right, @right)
     assert decrypted == {:ok, data}
   end
 


### PR DESCRIPTION
@voltone @GriffinMB do you see any concerns with allowing a custom AAD when additional content needs to be added to the integrity?

[RFC 7518](https://www.rfc-editor.org/rfc/rfc7518#section-4.7) specifies empty and we already defaulted to A128GCM, which is preserved, but I wonder if you have any concerns.

Thank you!