### PR TITLE
Improve tests with custom AAD

### DIFF
--- a/test/plug/crypto/message_encryptor_test.exs
+++ b/test/plug/crypto/message_encryptor_test.exs
@@ -13,13 +13,13 @@ defmodule Plug.Crypto.MessageEncryptorTest do
     data = <<0, "hełłoworld", 0>>
     encrypted = ME.encrypt(<<0, "hełłoworld", 0>>, "right aad", @right, @right)
 
-    decrypted = ME.decrypt(encrypted, @wrong, @wrong)
+    decrypted = ME.decrypt(encrypted, "right aad", @wrong, @wrong)
     assert decrypted == :error
 
-    decrypted = ME.decrypt(encrypted, @right, @wrong)
+    decrypted = ME.decrypt(encrypted, "right aad", @right, @wrong)
     assert decrypted == :error
 
-    decrypted = ME.decrypt(encrypted, @wrong, @right)
+    decrypted = ME.decrypt(encrypted, "right aad", @wrong, @right)
     assert decrypted == :error
 
     decrypted = ME.decrypt(encrypted, "wrong aad", @right, @right)


### PR DESCRIPTION
Sorry, I was asleep when #33 was being discussed...

If these tests don't pass in the custom AAD, then they will succeed (return `:error`) even with the right values for `secret` and `sign_secret`. Need to pass the correct AAD for them to actually test the wrong `secret` and `sign_secret`.