### PR TITLE
Work around missing function support

### DIFF
--- a/lib/plug/crypto.ex
+++ b/lib/plug/crypto.ex
@@ -131,24 +131,22 @@ defmodule Plug.Crypto do
   end
 
   # TODO: remove when we require OTP 25.0
-  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :hash_equals, 2) do
-    defp crypto_hash_equals(x, y) do
+  defp crypto_hash_equals(x, y) do
+    if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :hash_equals, 2) do
       :crypto.hash_equals(x, y)
-    end
-  else
-    defp crypto_hash_equals(x, y) do
+    else
       legacy_secure_compare(x, y, 0)
     end
+  end
 
-    defp legacy_secure_compare(<<x, left::binary>>, <<y, right::binary>>, acc) do
-      import Bitwise
-      xorred = bxor(x, y)
-      legacy_secure_compare(left, right, acc ||| xorred)
-    end
+  defp legacy_secure_compare(<<x, left::binary>>, <<y, right::binary>>, acc) do
+    import Bitwise
+    xorred = bxor(x, y)
+    legacy_secure_compare(left, right, acc ||| xorred)
+  end
 
-    defp legacy_secure_compare(<<>>, <<>>, acc) do
-      acc === 0
-    end
+  defp legacy_secure_compare(<<>>, <<>>, acc) do
+    acc === 0
   end
 
   @doc """

--- a/lib/plug/crypto.ex
+++ b/lib/plug/crypto.ex
@@ -133,7 +133,13 @@ defmodule Plug.Crypto do
   # TODO: remove when we require OTP 25.0
   defp crypto_hash_equals(x, y) do
     if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :hash_equals, 2) do
-      :crypto.hash_equals(x, y)
+      try do
+        :crypto.hash_equals(x, y)
+      rescue
+        # Still can throw "Unsupported CRYPTO_memcmp"
+        ErlangError ->
+          legacy_secure_compare(x, y, 0)
+      end
     else
       legacy_secure_compare(x, y, 0)
     end


### PR DESCRIPTION
This fixes two issues:

1. crypto.hash_equals can be present but unsupported (in which case it throws)

2. When compiling beam files on an older otp revision than deploying , the compile time detection reports false positives. Instead we're using runtime detection now always.