### PR TITLE
Reject tokens with future signed_at timestamps

### DIFF
--- a/test/plug/crypto_test.exs
+++ b/test/plug/crypto_test.exs
@@ -200,6 +200,11 @@ defmodule Plug.CryptoTest do
                {:error, :expired}
     end
 
+    test "ensures signed_at is not in future while decrypting" do
+      token = encrypt(@key, "secret", 1, signed_at: System.os_time(:second) + 31_536_000)
+      assert {:error, :invalid} = decrypt(@key, "secret", token)
+    end
+
     test "passes key_iterations options to key generator" do
       signed1 = encrypt(@key, "secret", 1, signed_at: 0, key_iterations: 1)
       signed2 = encrypt(@key, "secret", 1, signed_at: 0, key_iterations: 2)


### PR DESCRIPTION
This PR ensures that tokens with a `signed_at` timestamp in the future are treated as invalid during decryption.

Currently, if a token has a future `signed_at`, it can remain valid longer than the configured `max_age`. This undermines the expiration logic that `max_age` is meant to enforce.

Here’s an example:

```elixir
token = Plug.Crypto.encrypt("supersecret", "test", 1, [signed_at: System.os_time(:second) + 30, max_age: 10])
Plug.Crypto.decrypt("supersecret", "test", token) # This will work for 30 seconds instead of the expected 10
```

While `:infinity` is an option for long-lived tokens, when `max_age` is to seconds value, developers expect it to be enforced consistently. This change brings the implementation in line with that expectation.

I just set this to return `{:error, :invalid}`, but I am curious your thoughts on improvements to the API, as this would be be a breaking change. However, `{:error, :expired}` does not seem to really communicate to the caller what is truly the issue. As a consumer, I'd like to be able to see these tokens in my logs so I can detect when this happens.

Thank you!